### PR TITLE
on paste, put image file path into clipboard

### DIFF
--- a/Desktop/Desktop.cs
+++ b/Desktop/Desktop.cs
@@ -297,7 +297,7 @@ namespace Desktop
       } catch (Exception ex) { failReason = (ex.InnerException != null ? ex.InnerException.Message : ex.Message); }
 
       if (result) {
-        Uploaded("Image", "", "");
+        Uploaded("Image", DesktopPath + "/" + filename, "");
       } else {
         Failed(failReason);
       }


### PR DESCRIPTION
after successfully writing an image file from clipboard, put the path to the image file on the clipboard.  At least for my use case (dealing with programs/websites/etc that don't allow pasting an image from the clipboard directly), I need to get the file path to paste into the open/attach file dialog.

Thought about putting this behind a setting, but didn't want to make it more complicated and have to modify the UI if this change is acceptable. Also thought about a setting for 'write to temp instead of desktop' since for my use case, once the file has been uploaded (usually a few seconds after it being created), it's not really needed any more.  That's largely orthogonal to setting the file path into the clipboard, though.

The file path would be 'cleaner' if the changed line used a backslash instead of forward slash, but I kept it like the other sites to try and maintain consistency (and since the forward slash doesn't prevent the path from being used in open file dialogs)

Tested locally, with one oddity being that the tray tooltip includes "and URL copied to clipboard" when it's not really a URL - making it into a file:// URL would make it less useful than a filesystem path in my experience.  
https://github.com/NimbleTools/Clipupload/blob/0543035f876237d49b7634b6e1e02e94b7b5e87b/AddonHelper/Addon.cs#L394
